### PR TITLE
docs(flutter): update Google Sign-In sample for google_sign_in v7.x

### DIFF
--- a/apps/docs/content/guides/auth/social-login/auth-google.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-google.mdx
@@ -104,46 +104,91 @@ To use Google's pre-built signin buttons:
 
   </TabPanel>
 
-  <TabPanel id="flutter" label="Flutter">
 
-    ### iOS and Android
+<TabPanel id="flutter" label="Flutter">
 
-    1. Configure Web, Android, and iOS OAuth credentials. Follow the Platform integration instructions on the [README of google_sign_in package](https://pub.dev/packages/google_sign_in#platform-integration) for Android and iOS.
-        - For both Android and iOS, you will need to create a Web client ID in the [Google Cloud Console](https://console.cloud.google.com/apis/credentials).
-        - For Android, use the instructions on screen to provide the SHA-1 certificate fingerprint used to sign your Android app.
-          - You will have a different set of SHA-1 certificate fingerprint for testing locally and going to production. Make sure to add both to the Google Cloud Console. and add all of the Client IDs to Supabase dashboard.
-        - For iOS, use the instructions on screen to provide the app Bundle ID, and App Store ID and Team ID if the app is already published on the Apple App Store.
-    2. Configure the [OAuth Consent Screen](https://console.cloud.google.com/apis/credentials/consent). This information is shown to the user when giving consent to your app. In particular, make sure you have set up links to your app's privacy policy and terms of service.
-    3. Add only the web client ID from step 1 in the [Google provider on the Supabase Dashboard](https://supabase.com/dashboard/project/_/auth/providers), under _Client IDs_. If you need iOS support, enable the `Skip nonce check` option.
-    4. For iOS, add the `CFBundleURLTypes` attributes below into the `/ios/Runner/Info.plist` file.
-        ```xml
-        <!-- Put me in the [my_project]/ios/Runner/Info.plist file -->
-        <!-- Google Sign-in Section -->
-        <key>CFBundleURLTypes</key>
-        <array>
-          <dict>
-            <key>CFBundleTypeRole</key>
-            <string>Editor</string>
-            <key>CFBundleURLSchemes</key>
-            <array>
-              <!-- TODO Replace this value: -->
-              <!-- Copied from GoogleService-Info.plist key REVERSED_CLIENT_ID -->
-              <string>com.googleusercontent.apps.861823949799-vc35cprkp249096uujjn0vvnmcvjppkn</string>
-            </array>
-          </dict>
-        </array>
-        <!-- End of the Google Sign-in Section -->
-        ```
+### iOS and Android
 
-    ### Web, macOS, Windows, and Linux
+> [!IMPORTANT]
+> The Flutter Google Sign In integration has breaking changes in google_sign_in version 7.x.
+> Be sure to update your code as shown below and see the [official migration guide](https://github.com/flutter/packages/blob/main/packages/google_sign_in/google_sign_in/MIGRATION.md) for details.
 
-    To use the OAuth 2.0 flow, you will require the following information:
+Google sign-in with Supabase is done through the [google_sign_in](https://pub.dev/packages/google_sign_in) package for iOS and Android.
 
-    1. Obtain OAuth credentials for your Google Cloud project in the [Credentials](https://console.developers.google.com/apis/credentials) page of the console. If you already have a web client ID, no need to create a new one. When creating a new credential, choose _Web application_. In _Authorized redirect URIs_ enter `https://<project-id>.supabase.co/auth/v1/callback`. This URL will be seen by your users, and you can customize it by configuring [custom domains](/docs/guides/platform/custom-domains).
-    2. Configure the [OAuth Consent Screen](https://console.cloud.google.com/apis/credentials/consent). This information is shown to the user when giving consent to your app. Within _Authorized domains_ make sure you add your Supabase project's domain `<project-id>.supabase.co`. Configure the non-sensitive scopes by making sure the following ones are selected: `.../auth/userinfo.email`, `.../auth/userinfo.profile`, `openid`. If you're selecting other sensitive scopes, your app may require additional verification. In those cases, it's best to use [custom domains](/docs/guides/platform/custom-domains).
-    3. Finally, add the client ID and secret from step 1 in the [Google provider on the Supabase Dashboard](https://supabase.com/dashboard/project/_/auth/providers).
+When the user provides consent, Google issues an identity token (commonly abbreviated as ID token) that is then sent to your project's Supabase Auth server. When valid, a new user session is started by issuing an access and refresh token from Supabase Auth.
 
-  </TabPanel>
+Follow the code sample below to implement native Google sign-in with Supabase in your Flutter iOS and Android app.  
+**Make sure to replace `webClientId` and `iosClientId` with your actual values from the Google Cloud Console.**
+
+```dart
+import 'package:google_sign_in/google_sign_in.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+final supabaseClient = Supabase.instance.client;
+
+Future<void> nativeGoogleSignIn() async {
+  // Update with your own client IDs
+  const webClientId = 'my-web.apps.googleusercontent.com';
+  const iosClientId = 'my-ios.apps.googleusercontent.com';
+
+  final scopes = ['email', 'profile'];
+  final googleSignIn = GoogleSignIn.instance;
+
+  await googleSignIn.initialize(
+    serverClientId: webClientId,
+    clientId: iosClientId,
+  );
+
+  final googleUser = await googleSignIn.attemptLightweightAuthentication();
+  if (googleUser == null) {
+    throw AuthException('Failed to sign in with Google.');
+  }
+
+  final authorization =
+      await googleUser.authorizationClient.authorizationForScopes(scopes) ??
+      await googleUser.authorizationClient.authorizeScopes(scopes);
+
+  final idToken = googleUser.authentication.idToken;
+  if (idToken == null) {
+    throw AuthException('No ID Token found.');
+  }
+
+  await supabaseClient.auth.signInWithIdToken(
+    provider: OAuthProvider.google,
+    idToken: idToken,
+    accessToken: authorization.accessToken,
+  );
+}
+```
+
+### Web, macOS, Windows, and Linux
+
+Google sign-in with Supabase on Web, macOS, Windows, and Linux is done through the [`signInWithOAuth`](docs/reference/dart/auth-signinwithoauth) method.
+
+This method of signing in is web based, and will open a browser window to perform the sign in. For non-web platforms, the user is brought back to the app via [deep linking](/docs/guides/auth/native-mobile-deep-linking?platform=flutter).
+
+```dart
+await supabase.auth.signInWithOAuth(
+  OAuthProvider.google,
+  redirectTo: kIsWeb ? null : 'my.scheme://my-host', // Optionally set the redirect link to bring back the user via deeplink.
+  authScreenLaunchMode:
+      kIsWeb ? LaunchMode.platformDefault : LaunchMode.externalApplication, // Launch the auth screen in a new webview on mobile.
+);
+```
+
+This call takes the user to Google's consent screen. Once the flow ends, the user's profile information is exchanged and validated with Supabase Auth before it redirects back to your Flutter application with an access and refresh token representing the user's session.
+
+<div className="video-container">
+  <iframe
+    src="https://www.youtube-nocookie.com/embed/utMg6fVmX0U"
+    frameBorder="1"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+    allowFullScreen
+  ></iframe>
+</div>
+
+</TabPanel>
+
 
   <TabPanel id="swift" label="Swift">
 


### PR DESCRIPTION
- Replaced outdated Flutter Google sign-in sample with one compatible with google_sign_in 7.x
- Added migration notice and link to official migration guide
- Resolves issue #36775

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

docs update

## What is the current behavior?

Documentation shows outdated Flutter sample code for Google sign-in (not compatible with google_sign_in v7.x)

## What is the new behavior?

Documentation now provides a correct example for google_sign_in v7.x, with a migration notice and resource link.